### PR TITLE
Autoconvert mpic++ to mpicc in SCHISM make fragment

### DIFF
--- a/src/incmake/component_BARDATA.mk
+++ b/src/incmake/component_BARDATA.mk
@@ -1,0 +1,68 @@
+###########################################################################
+### NUOPC GNUMake Macro File for the Baroclinic Modeling Component (BARDATA)
+###
+### Author: Panagiotis Velissariou <panagiotis.velissariou@noaa.gov>
+### Date:   March 04 2022
+###########################################################################
+
+
+########################################################################
+
+# Location of source code and installation
+BARDATA_SRCDIR?=$(ROOTDIR)/BARDATA
+BARDATA_BINDIR?=$(ROOTDIR)/BARDATA_INSTALL
+BARDATA_NUOPC_SRCDIR?=$(ROOTDIR)/BARDATA/nuopc
+
+# Location of the ESMF makefile fragment for this component:
+bardata_mk = $(BARDATA_BINDIR)/bardata.mk
+all_component_mk_files+=$(bardata_mk)
+
+# Make sure the expected directories exist and are non-empty:
+$(call require_dir,$(BARDATA_SRCDIR),BARDATA source directory)
+
+########################################################################
+
+# Rule for building this component:
+
+build_BARDATA: $(bardata_mk)
+
+$(bardata_mk):
+	+cd $(BARDATA_SRCDIR); exec ./build.sh --compiler=$(NEMS_COMPILER) --parallel=$(NEMS_PARALLEL) \
+	   --component=ogcmdl --prefix=$(BARDATA_BINDIR) \
+	   --cmake_flags="-DCMAKE_INSTALL_BINDIR=$(BARDATA_BINDIR) -DCMAKE_INSTALL_LIBDIR=$(BARDATA_BINDIR)" \
+	   --verbose
+	@if [ $$? -eq 0 ]; \
+	then \
+	  cd $(BARDATA_NUOPC_SRCDIR); \
+          export BARDATA_BINDIR=$(BARDATA_BINDIR); \
+          exec $(MAKE) install DESTDIR=/ "INSTDIR=$(BARDATA_BINDIR)"; \
+	  echo ""; \
+	  test -d "$(BARDATA_BINDIR)"; \
+	  echo ""; \
+	  test -s $(bardata_mk); \
+	  echo ""; \
+	else \
+          echo "ERROR: could not compile the NUOPC Cap due to BARDATA build errors"; \
+	  exit 1; \
+	fi
+
+########################################################################
+
+# Rule for cleaning the SRCDIR and BINDIR:
+
+clean_BARDATA_NUOPC:
+	+cd $(BARDATA_NUOPC_SRCDIR); exec $(MAKE) clean
+	@echo ""
+
+distclean_BARDATA_NUOPC:
+	+cd $(BARDATA_NUOPC_SRCDIR); exec $(MAKE) distclean
+	@echo ""
+
+clean_BARDATA: clean_BARDATA_NUOPC
+	+cd $(BARDATA_SRCDIR); exec ./build.sh --clean=1
+	@echo ""
+
+distclean_BARDATA: distclean_BARDATA_NUOPC
+	+cd $(BARDATA_SRCDIR); exec ./build.sh --clean=2
+	rm -rf $(BARDATA_BINDIR)
+	@echo ""

--- a/src/incmake/component_PAHM.mk
+++ b/src/incmake/component_PAHM.mk
@@ -29,7 +29,7 @@ build_PAHM: $(pahm_mk)
 $(pahm_mk):
 	+cd $(PAHM_SRCDIR); exec ./build.sh --compiler=$(NEMS_COMPILER) --plat=$(NEMS_PLATFORM) --parallel=$(NEMS_PARALLEL) \
 	   --prefix=$(PAHM_BINDIR) --cmake_flags="-DCMAKE_INSTALL_BINDIR=$(PAHM_BINDIR) -DCMAKE_INSTALL_LIBDIR=$(PAHM_BINDIR)" \
-	   --verbose=1
+	   --verbose=1 --yes=$(ACCEPT_ALL)
 	@if [ $$? -eq 0 ]; \
 	then \
 	  cd $(PAHM_NUOPC_SRCDIR); \
@@ -66,10 +66,10 @@ distclean_PAHM_NUOPC: nuopc_makefile
 	@echo ""
 
 clean_PAHM: clean_PAHM_NUOPC
-	+cd $(PAHM_SRCDIR); exec ./build.sh --clean=1
+	+cd $(PAHM_SRCDIR); exec ./build.sh --clean=1 --yes=$(ACCEPT_ALL)
 	@echo ""
 
 distclean_PAHM: distclean_PAHM_NUOPC
-	+cd $(PAHM_SRCDIR); exec ./build.sh --clean=2
+	+cd $(PAHM_SRCDIR); exec ./build.sh --clean=2 --yes=$(ACCEPT_ALL)
 	rm -rf $(PAHM_BINDIR)
 	@echo ""

--- a/src/incmake/component_SCHISM.mk
+++ b/src/incmake/component_SCHISM.mk
@@ -27,6 +27,9 @@ endif
 ifeq ($(ESMF_CCOMPILER),$(ESMF_CXXCOMPILER))
 ESMF_CCOMPILER:=$(subst mpicpc,mpicc,$(ESMF_CXXCOMPILER))
 endif
+ifeq ($(ESMF_CCOMPILER),$(ESMF_CXXCOMPILER))
+ESMF_CCOMPILER:=$(subst mpic++,mpicc,$(ESMF_CXXCOMPILER))
+endif
 
 # Location of the ESMF makefile fragment for this component:
 schism_mk = $(SCHISM_BINDIR)/schism.mk

--- a/src/module_EARTH_GRID_COMP.F90
+++ b/src/module_EARTH_GRID_COMP.F90
@@ -99,6 +99,9 @@
 #ifdef FRONT_WW3DATA
       use FRONT_WW3DATA,    only: WW3DATA_SS  => SetServices
 #endif
+#ifdef FRONT_BARDATA
+      use FRONT_BARDATA,     only: BARDATA_SS  => SetServices
+#endif
 #ifdef FRONT_ATMESH
       use FRONT_ATMESH,     only: ATMESH_SS  => SetServices
 #endif
@@ -3978,6 +3981,19 @@
           elseif (trim(model) == "ww3data") then
 #ifdef FRONT_WW3DATA
             call NUOPC_DriverAddComp(driver, trim(prefix), WW3DATA_SS, &
+              petList=petList, comp=comp, rc=rc)
+            if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+              line=__LINE__, file=trim(name)//":"//__FILE__)) return  !  bail out
+#else
+            write (msg, *) "Model '", trim(model), "' was requested, "// &
+              "but is not available in the executable!"
+            call ESMF_LogSetError(ESMF_RC_NOT_VALID, msg=msg, line=__LINE__, &
+              file=__FILE__, rcToReturn=rc)
+            return  ! bail out
+#endif
+          elseif (trim(model) == "bardata") then
+#ifdef FRONT_BARDATA
+            call NUOPC_DriverAddComp(driver, trim(prefix), BARDATA_SS, &
               petList=petList, comp=comp, rc=rc)
             if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
               line=__LINE__, file=trim(name)//":"//__FILE__)) return  !  bail out


### PR DESCRIPTION
On levante with Openmpi, we need to convert from CXX to CC, i.e. from mpic++ to mpicc in SCHISM's makefile fragment